### PR TITLE
docs: adiciona página de aviso legal e rodapé automático via MkDocs hook

### DIFF
--- a/docs/aviso_legal.md
+++ b/docs/aviso_legal.md
@@ -20,6 +20,13 @@ Os únicos resultados oficiais, para todos os fins legais, regulatórios e contr
 Este material não se presta à fundamentação de pleitos administrativos, contratuais ou judiciais, tampouco à instrução de defesas, recursos ou impugnações por parte de operadores, concessionárias ou quaisquer terceiros.
 
 A utilização deste conteúdo para tais finalidades será considerada interpretação indevida de sua natureza e finalidade.
+Os únicos resultados oficiais, para todos os fins legais, regulatórios e contratuais, são aqueles gerados diretamente pelos sistemas e modelos computacionais mantidos e executados pela SMTR em ambiente institucional controlado.
+
+## Uso e Interpretação
+
+Este material não se presta à fundamentação de pleitos administrativos, contratuais ou judiciais, tampouco à instrução de defesas, recursos ou impugnações por parte de operadores, concessionárias ou quaisquer terceiros.
+
+A utilização deste conteúdo para tais finalidades será considerada interpretação indevida de sua natureza e finalidade.
 ## Limitações e Precedência
 
 Em hipótese alguma este documento substitui, altera ou modifica as disposições contidas na

--- a/docs/aviso_legal.md
+++ b/docs/aviso_legal.md
@@ -5,7 +5,7 @@
 Toda a documentação contida neste site possui caráter meramente
 técnico-descritivo, destinado a detalhar, de forma didática, os procedimentos, fluxos de dados,
 parâmetros e indicadores utilizados pela Secretaria Municipal de Transportes.
-
+Este conteúdo possui caráter exclusivamente informativo e não constitui ato administrativo, norma técnica oficial, instrução normativa ou qualquer forma de manifestação vinculante da Administração Pública, não gerando direitos, obrigações ou expectativas legítimas a terceiros.
 ## Geração Automatizada
 
 Esta documentação é gerada e atualizada automaticamente com auxílio de **inteligência artificial**
@@ -13,6 +13,13 @@ Esta documentação é gerada e atualizada automaticamente com auxílio de **int
 repositórios [pipelines_v3](https://github.com/RJ-SMTR/pipelines_v3) e
 [pipelines_rj_smtr](https://github.com/prefeitura-rio/pipelines_rj_smtr).
 
+Os únicos resultados oficiais, para todos os fins legais, regulatórios e contratuais, são aqueles gerados diretamente pelos sistemas e modelos computacionais mantidos e executados pela SMTR em ambiente institucional controlado.
+
+## Uso e Interpretação
+
+Este material não se presta à fundamentação de pleitos administrativos, contratuais ou judiciais, tampouco à instrução de defesas, recursos ou impugnações por parte de operadores, concessionárias ou quaisquer terceiros.
+
+A utilização deste conteúdo para tais finalidades será considerada interpretação indevida de sua natureza e finalidade.
 ## Limitações e Precedência
 
 Em hipótese alguma este documento substitui, altera ou modifica as disposições contidas na

--- a/docs/aviso_legal.md
+++ b/docs/aviso_legal.md
@@ -2,18 +2,16 @@
 
 ## Natureza do Documento
 
-Este documento — e toda a documentação contida neste site — possui caráter meramente
+Toda a documentação contida neste site possui caráter meramente
 técnico-descritivo, destinado a detalhar, de forma didática, os procedimentos, fluxos de dados,
-parâmetros e indicadores utilizados pela Secretaria Municipal de Transportes para a apuração de
-viagens e quilometragem do SPPO/RJ.
+parâmetros e indicadores utilizados pela Secretaria Municipal de Transportes.
 
 ## Geração Automatizada
 
 Esta documentação é gerada e atualizada automaticamente com auxílio de **inteligência artificial**
 (Claude, Anthropic) a partir da análise estrutural do código-fonte e dos modelos de dados dos
 repositórios [pipelines_v3](https://github.com/RJ-SMTR/pipelines_v3) e
-[pipelines_rj_smtr](https://github.com/prefeitura-rio/pipelines_rj_smtr). Todo conteúdo gerado
-passa por revisão da equipe técnica da SMTR antes da publicação.
+[pipelines_rj_smtr](https://github.com/prefeitura-rio/pipelines_rj_smtr).
 
 ## Limitações e Precedência
 

--- a/docs/aviso_legal.md
+++ b/docs/aviso_legal.md
@@ -2,54 +2,53 @@
 
 ## Natureza do Documento
 
-Toda a documentação contida neste site possui caráter meramente
-técnico-descritivo, destinado a detalhar, de forma didática, os procedimentos, fluxos de dados,
-parâmetros e indicadores utilizados pela Secretaria Municipal de Transportes.
+Toda a documentação contida neste site possui caráter meramente técnico-descritivo, destinado a detalhar, de forma didática, os procedimentos, fluxos de dados, parâmetros e indicadores utilizados pela Secretaria Municipal de Transportes.
+
 Este conteúdo possui caráter exclusivamente informativo e não constitui ato administrativo, norma técnica oficial, instrução normativa ou qualquer forma de manifestação vinculante da Administração Pública, não gerando direitos, obrigações ou expectativas legítimas a terceiros.
+
+---
+
 ## Geração Automatizada
 
-Esta documentação é gerada e atualizada automaticamente com auxílio de **inteligência artificial**
-(Claude, Anthropic) a partir da análise estrutural do código-fonte e dos modelos de dados dos
-repositórios [pipelines_v3](https://github.com/RJ-SMTR/pipelines_v3) e
-[pipelines_rj_smtr](https://github.com/prefeitura-rio/pipelines_rj_smtr).
+Esta documentação é gerada e atualizada automaticamente com auxílio de inteligência artificial (Claude, Anthropic), a partir da análise estrutural do código-fonte e dos modelos de dados dos repositórios [pipelines_v3](https://github.com/RJ-SMTR/pipelines_v3) e [pipelines_rj_smtr](https://github.com/prefeitura-rio/pipelines_rj_smtr).
 
 Os únicos resultados oficiais, para todos os fins legais, regulatórios e contratuais, são aqueles gerados diretamente pelos sistemas e modelos computacionais mantidos e executados pela SMTR em ambiente institucional controlado.
+
+---
 
 ## Uso e Interpretação
 
 Este material não se presta à fundamentação de pleitos administrativos, contratuais ou judiciais, tampouco à instrução de defesas, recursos ou impugnações por parte de operadores, concessionárias ou quaisquer terceiros.
 
 A utilização deste conteúdo para tais finalidades será considerada interpretação indevida de sua natureza e finalidade.
-Os únicos resultados oficiais, para todos os fins legais, regulatórios e contratuais, são aqueles gerados diretamente pelos sistemas e modelos computacionais mantidos e executados pela SMTR em ambiente institucional controlado.
 
-## Uso e Interpretação
+Este documento não possui natureza de registro oficial de execução, log operacional, trilha de auditoria ou evidência técnica formal dos processos computacionais, não devendo ser utilizado para fins de verificação, validação ou certificação de resultados.
 
-Este material não se presta à fundamentação de pleitos administrativos, contratuais ou judiciais, tampouco à instrução de defesas, recursos ou impugnações por parte de operadores, concessionárias ou quaisquer terceiros.
+A disponibilização pública desta documentação não implica garantia de estabilidade das regras descritas, nem compromisso de manutenção de critérios, parâmetros ou metodologias aqui apresentados, os quais podem ser alterados a qualquer tempo nos modelos computacionais oficiais, observada a legislação aplicável.
 
-A utilização deste conteúdo para tais finalidades será considerada interpretação indevida de sua natureza e finalidade.
+Este material não substitui documentos formais de prestação de contas, relatórios oficiais, bases de dados certificadas ou quaisquer instrumentos institucionais destinados à fiscalização e controle, devendo tais finalidades ser atendidas por meios próprios e formais.
+
+---
+
 ## Limitações e Precedência
 
-Em hipótese alguma este documento substitui, altera ou modifica as disposições contidas na
-legislação municipal, em normas regulamentares, em decisões judiciais ou em atos administrativos
-vigentes, nem o modelo computacional oficial parametrizado pela SMTR.
+Em hipótese alguma este documento substitui, altera ou modifica as disposições contidas na legislação municipal, em normas regulamentares, em decisões judiciais ou em atos administrativos vigentes, nem o modelo computacional oficial parametrizado pela SMTR.
 
-Para todos os efeitos legais e operacionais, em caso de divergência ou inconsistência entre as
-informações aqui descritas e:
+Esta documentação não constitui representação fiel, completa ou necessariamente atualizada do comportamento operacional dos modelos em produção, devendo eventuais divergências ser resolvidas exclusivamente com base nos modelos computacionais oficiais e nos resultados por eles produzidos.
 
-1. **A legislação vigente** (leis, decretos, resoluções e demais normas aplicáveis) —
-   **prevalecerá a legislação**;
-2. **Os modelos computacionais oficiais** publicados nos repositórios da
-   [SMTR](https://github.com/prefeitura-rio/pipelines_rj_smtr) e
-   [RJ-SMTR](https://github.com/RJ-SMTR/pipelines_v3) —
-   **prevalecerão os resultados gerados por estes modelos**;
-3. **Este documento**, que será interpretado como instrumento complementar, com função de apoio e
-   transparência, **não vinculando a Administração** em detrimento das normas e modelos oficiais.
+Eventuais inconsistências, omissões ou simplificações existentes neste material não implicam reconhecimento de erro, falha ou inadequação dos sistemas oficiais, tampouco geram qualquer presunção de irregularidade na apuração dos resultados institucionais.
+
+Para todos os efeitos legais e operacionais, em caso de divergência ou inconsistência entre as informações aqui descritas e:
+
+1. A legislação vigente (leis, decretos, resoluções e demais normas aplicáveis) — prevalecerá a legislação;
+2. **Os modelos computacionais oficiais** publicados nos repositórios da [SMTR](https://github.com/prefeitura-rio/pipelines_rj_smtr) e [RJ-SMTR](https://github.com/RJ-SMTR/pipelines_v3) — **prevalecerão os resultados gerados por estes modelos**;
+3. Este documento — que será interpretado como instrumento complementar, com função de apoio e transparência, não vinculando a Administração em detrimento das normas e modelos oficiais.
+
+---
 
 ## Atualizações
 
-Eventuais ajustes ou atualizações técnicas na pipeline poderão ser implementados e refletidos no
-modelo oficial, observando-se sempre os parâmetros definidos em norma e os princípios de
-legalidade, publicidade e transparência administrativa.
+Eventuais ajustes ou atualizações técnicas na pipeline poderão ser implementados e refletidos no modelo oficial, observando-se sempre os parâmetros definidos em norma e os princípios de legalidade, publicidade e transparência administrativa.
 
 ---
 

--- a/docs/aviso_legal.md
+++ b/docs/aviso_legal.md
@@ -1,0 +1,44 @@
+# Aviso Legal
+
+## Natureza do Documento
+
+Este documento — e toda a documentação contida neste site — possui caráter meramente
+técnico-descritivo, destinado a detalhar, de forma didática, os procedimentos, fluxos de dados,
+parâmetros e indicadores utilizados pela Secretaria Municipal de Transportes para a apuração de
+viagens e quilometragem do SPPO/RJ.
+
+## Geração Automatizada
+
+Esta documentação é gerada e atualizada automaticamente com auxílio de **inteligência artificial**
+(Claude, Anthropic) a partir da análise estrutural do código-fonte e dos modelos de dados dos
+repositórios [pipelines_v3](https://github.com/RJ-SMTR/pipelines_v3) e
+[pipelines_rj_smtr](https://github.com/prefeitura-rio/pipelines_rj_smtr). Todo conteúdo gerado
+passa por revisão da equipe técnica da SMTR antes da publicação.
+
+## Limitações e Precedência
+
+Em hipótese alguma este documento substitui, altera ou modifica as disposições contidas na
+legislação municipal, em normas regulamentares, em decisões judiciais ou em atos administrativos
+vigentes, nem o modelo computacional oficial parametrizado pela SMTR.
+
+Para todos os efeitos legais e operacionais, em caso de divergência ou inconsistência entre as
+informações aqui descritas e:
+
+1. **A legislação vigente** (leis, decretos, resoluções e demais normas aplicáveis) —
+   **prevalecerá a legislação**;
+2. **Os modelos computacionais oficiais** publicados nos repositórios da
+   [SMTR](https://github.com/prefeitura-rio/pipelines_rj_smtr) e
+   [RJ-SMTR](https://github.com/RJ-SMTR/pipelines_v3) —
+   **prevalecerão os resultados gerados por estes modelos**;
+3. **Este documento**, que será interpretado como instrumento complementar, com função de apoio e
+   transparência, **não vinculando a Administração** em detrimento das normas e modelos oficiais.
+
+## Atualizações
+
+Eventuais ajustes ou atualizações técnicas na pipeline poderão ser implementados e refletidos no
+modelo oficial, observando-se sempre os parâmetros definidos em norma e os princípios de
+legalidade, publicidade e transparência administrativa.
+
+---
+
+*Secretaria Municipal de Transportes — Prefeitura da Cidade do Rio de Janeiro*

--- a/docs/static/extra.css
+++ b/docs/static/extra.css
@@ -17,3 +17,8 @@
     height: auto;
     width: 15%;
 }
+
+.admonition .twemoji {
+    --md-icon-size: 2em;
+    vertical-align: text-bottom;
+}

--- a/hooks/disclaimer_footer.py
+++ b/hooks/disclaimer_footer.py
@@ -20,7 +20,7 @@ FOOTER_TEMPLATE = """\
 
 !!! warning "Aviso Legal"
 
-    :material-robot: *Este documento foi gerado automaticamente com auxílio de
+    :material-robot-happy: *Este documento foi gerado automaticamente com auxílio de
     inteligência artificial.*
 
     Este documento possui caráter meramente técnico-descritivo e pode conter erros. Para mais

--- a/hooks/disclaimer_footer.py
+++ b/hooks/disclaimer_footer.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+MkDocs hook — Injeta rodapé com aviso legal em todas as páginas de documentação.
+
+Configuração no mkdocs.yml:
+    hooks:
+      - hooks/disclaimer_footer.py
+
+Ref: https://www.mkdocs.org/user-guide/configuration/#hooks
+"""
+
+import posixpath
+
+# Páginas que NÃO recebem o rodapé (caminhos relativos à raiz de docs/)
+EXCLUDE_PAGES = {"aviso_legal.md", "index.md"}
+
+FOOTER_TEMPLATE = """\
+
+---
+
+!!! warning "Aviso Legal"
+
+    :material-robot: *Este documento foi gerado automaticamente com auxílio de
+    inteligência artificial e revisado pela equipe técnica da SMTR.*
+
+    Este documento possui caráter meramente técnico-descritivo. Para mais
+    informações, consulte o [Aviso Legal completo]({disclaimer_url}).
+"""
+
+
+def _relative_url(from_page: str, to_page: str) -> str:
+    """Calcula o caminho relativo entre duas páginas MkDocs."""
+    from_dir = posixpath.dirname(from_page)
+    return posixpath.relpath(to_page, from_dir)
+
+
+def on_page_markdown(markdown, page, config, files, **kwargs):
+    """Appenda o rodapé de disclaimer ao final do markdown de cada página."""
+    src_path = page.file.src_path
+
+    if src_path in EXCLUDE_PAGES:
+        return markdown
+
+    disclaimer_url = _relative_url(src_path, "aviso_legal.md")
+    footer = FOOTER_TEMPLATE.format(disclaimer_url=disclaimer_url)
+
+    return markdown + footer

--- a/hooks/disclaimer_footer.py
+++ b/hooks/disclaimer_footer.py
@@ -21,9 +21,9 @@ FOOTER_TEMPLATE = """\
 !!! warning "Aviso Legal"
 
     :material-robot: *Este documento foi gerado automaticamente com auxílio de
-    inteligência artificial e revisado pela equipe técnica da SMTR.*
+    inteligência artificial.*
 
-    Este documento possui caráter meramente técnico-descritivo. Para mais
+    Este documento possui caráter meramente técnico-descritivo e pode conter erros. Para mais
     informações, consulte o [Aviso Legal completo]({disclaimer_url}).
 """
 

--- a/hooks/disclaimer_footer.py
+++ b/hooks/disclaimer_footer.py
@@ -24,7 +24,7 @@ FOOTER_TEMPLATE = """\
     inteligência artificial.*
 
     Este documento possui caráter meramente técnico-descritivo e pode conter erros. Para mais
-    informações, consulte o [Aviso Legal completo]({disclaimer_url}).
+    informações, consulte o [Aviso Legal]({disclaimer_url}) completo.
 """
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 site_name: SMTR -  Pipelines
 site_url: https://rj-smtr.github.io/pipelines-docs/
 
+hooks:
+  - hooks/disclaimer_footer.py
+
 nav:
   - Home: index.md # descrição das pessoas, repositórios, da documentação
   - Quick Start: quick_start.md # setar ambiente virtual, instalar com poetry, mencionar o infisical, configuração por OS
@@ -19,6 +22,7 @@ nav:
           - FAQ: pipelines/listagem_pipelines/faq.md # perguntas frequentes sobre as pipelines de apuração do subsídio
   - Datasets: datasets.md # histórico dos datasets já existentes
   - Ferramentas: ferramentas.md # ferramentas e versões utilizadas
+  - Aviso Legal: aviso_legal.md
 
 theme:
   name: material
@@ -45,6 +49,8 @@ theme:
   language: pt
 
 markdown_extensions:
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,9 @@ nav:
       - Listagem das pipelines: # histórico das pipelines já existentes, para cada uma falar dos parâmetros e do que se trata
           - Monitoramento:
               - Apuração de viagens (SPPO) [1.0]: pipelines/listagem_pipelines/monitoramento/apuracao_viagens_v1.md # pipeline de apuração de viagens v1
+              - Apuração de viagens (SPPO) [10.0]: pipelines/listagem_pipelines/monitoramento/apuracao_viagens_v10.md # pipeline de apuração de viagens v10
           - FAQ: pipelines/listagem_pipelines/faq.md # perguntas frequentes sobre as pipelines de apuração do subsídio
+  - Data Clean Rooms: datacleanrooms.md # tutorial de Data Clean Rooms no BigQuery
   - Datasets: datasets.md # histórico dos datasets já existentes
   - Ferramentas: ferramentas.md # ferramentas e versões utilizadas
   - Aviso Legal: aviso_legal.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 extra:
   social:


### PR DESCRIPTION
## Summary

- Adiciona página `docs/aviso_legal.md` com disclaimer legal completo (natureza do documento, geração por IA, limitações e precedência)
- Adiciona hook MkDocs (`hooks/disclaimer_footer.py`) que injeta rodapé de aviso legal automaticamente em todas as páginas
- Configura extensões `admonition` e `pymdownx.details` no `mkdocs.yml` para suporte ao admonition do rodapé
- Adiciona entrada "Aviso Legal" na navegação

O rodapé é injetado automaticamente pelo MkDocs no build — não depende de autores lembrarem de incluí-lo manualmente. Páginas excluídas do rodapé: `aviso_legal.md` (a própria) e `index.md`.